### PR TITLE
Remove DollarSign icon from events price display

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -16,8 +16,7 @@ import {
   Filter,
   MapPin,
   Calendar,
-  Users,
-  DollarSign
+  Users
 } from 'lucide-react';
 
 interface EventItem {
@@ -257,7 +256,6 @@ export default function AdminEventsPage() {
                           {event.currentBookings || 0}/{event.maxParticipants}
                         </div>
                         <div className="flex items-center font-semibold text-primary">
-                          <DollarSign className="h-4 w-4 mr-1" />
                           <span>₹{event.price.toLocaleString()}</span>
                         </div>
                       </div>


### PR DESCRIPTION
- Remove DollarSign import from lucide-react
- Remove DollarSign icon from price display div in admin events page
- Keep only rupee symbol (₹) for cleaner price display